### PR TITLE
fix: Add vhost.conf

### DIFF
--- a/ds_config_example.php
+++ b/ds_config_example.php
@@ -8,7 +8,7 @@ $DS_CONFIG = [
     'ds_client_secret' => '{SECRET_KEY}', // The app's DocuSign integration key's secret
     'signer_email' => '{SIGNER_EMAIL}',
     'signer_name' => '{SIGNER_NAME}',
-    'app_url' => 'http://localhost:8080/public', // The url of the application.
+    'app_url' => 'http://localhost:8080', // The url of the application.
     // Ie, the user enters  app_url in their browser to bring up the app's home page
     // Eg http://localhost/code-examples-php/public if the app is installed in a
     // development directory that is accessible via web server.

--- a/vhost.conf
+++ b/vhost.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80 default_server;
+    server_name docusign;
+
+    root /var/www/html/public;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_index index.php;
+        send_timeout 1800;
+        fastcgi_read_timeout 1800;
+        fastcgi_pass php-fpm:9000;
+    }
+}


### PR DESCRIPTION
When cloning this repo or using the quickstart from developers.docusign.com, you want to start the demo with `docker-compose up`. This results in an error because the `vhost.conf` file does not exist.

Not sure if this is the correct vhost.conf file, but it works for me. I did have to change the default `app_url` though.